### PR TITLE
Feature/update toggle

### DIFF
--- a/web/components/headers/cycle-issues.tsx
+++ b/web/components/headers/cycle-issues.tsx
@@ -22,6 +22,7 @@ import { ISSUE_DISPLAY_FILTERS_BY_LAYOUT } from "constants/issue";
 import { EFilterType } from "store/issues/types";
 import { EProjectStore } from "store/command-palette.store";
 import { EUserWorkspaceRoles } from "constants/workspace";
+import { CycleEditToggle } from "components/issues/issue-layouts/filters/header/edit-toggle";
 
 export const CycleIssuesHeader: React.FC = observer(() => {
   const [analyticsModal, setAnalyticsModal] = useState(false);
@@ -172,6 +173,7 @@ export const CycleIssuesHeader: React.FC = observer(() => {
             onChange={(layout) => handleLayoutChange(layout)}
             selectedLayout={activeLayout}
           />
+          <CycleEditToggle />
           <FiltersDropdown title="Filters" placement="bottom-end">
             <FilterSelection
               filters={issueFilters?.filters ?? {}}

--- a/web/components/headers/project-view-issues.tsx
+++ b/web/components/headers/project-view-issues.tsx
@@ -18,7 +18,7 @@ import { ISSUE_DISPLAY_FILTERS_BY_LAYOUT } from "constants/issue";
 import { EFilterType } from "store/issues/types";
 import { EProjectStore } from "store/command-palette.store";
 import { EUserWorkspaceRoles } from "constants/workspace";
-import UpdateToggle from "components/issues/issue-layouts/filters/header/edit-toggle";
+import { ViewEditToggle } from "components/issues/issue-layouts/filters/header/edit-toggle";
 
 export const ProjectViewIssuesHeader: React.FC = observer(() => {
   const router = useRouter();
@@ -156,7 +156,7 @@ export const ProjectViewIssuesHeader: React.FC = observer(() => {
           onChange={(layout) => handleLayoutChange(layout)}
           selectedLayout={activeLayout}
         />
-        <UpdateToggle />
+        <ViewEditToggle />
         <FiltersDropdown title="Filters" placement="bottom-end" disabled={!canUserCreateIssue}>
           <FilterSelection
             filters={issueFilters?.filters ?? {}}

--- a/web/components/headers/project-view-issues.tsx
+++ b/web/components/headers/project-view-issues.tsx
@@ -18,6 +18,7 @@ import { ISSUE_DISPLAY_FILTERS_BY_LAYOUT } from "constants/issue";
 import { EFilterType } from "store/issues/types";
 import { EProjectStore } from "store/command-palette.store";
 import { EUserWorkspaceRoles } from "constants/workspace";
+import UpdateToggle from "components/issues/issue-layouts/filters/header/edit-toggle";
 
 export const ProjectViewIssuesHeader: React.FC = observer(() => {
   const router = useRouter();
@@ -155,7 +156,7 @@ export const ProjectViewIssuesHeader: React.FC = observer(() => {
           onChange={(layout) => handleLayoutChange(layout)}
           selectedLayout={activeLayout}
         />
-
+        <UpdateToggle />
         <FiltersDropdown title="Filters" placement="bottom-end" disabled={!canUserCreateIssue}>
           <FilterSelection
             filters={issueFilters?.filters ?? {}}

--- a/web/components/headers/workspace-dashboard.tsx
+++ b/web/components/headers/workspace-dashboard.tsx
@@ -41,7 +41,7 @@ export const WorkspaceDashboardHeader = () => {
           </a>
           <a
             className="flex flex-shrink-0 items-center gap-1.5 rounded bg-custom-background-80 px-3 py-1.5 text-xs font-medium"
-            href="https://github.com/makeplane/plane"
+            href="https://github.com/Alternova-Inc/plane"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/web/components/issues/issue-layouts/filters/header/edit-toggle/index.tsx
+++ b/web/components/issues/issue-layouts/filters/header/edit-toggle/index.tsx
@@ -1,0 +1,21 @@
+import { ToggleSwitch } from "@plane/ui";
+import { useMobxStore } from "lib/mobx/store-provider";
+import { observer } from "mobx-react-lite";
+
+const UpdateToggle: React.FC = observer(() => {
+
+  const { viewIssuesFilter: {isEditing, updateEditing} } = useMobxStore();
+
+  return (
+    <div className="flex items-center gap-2 border rounded p-1">
+      <label className="text-sm">Edit mode:</label>
+      <ToggleSwitch
+        label="Edit mode"
+        value={isEditing}
+        onChange={updateEditing}
+      />
+    </div>
+  );
+});
+
+export default UpdateToggle;

--- a/web/components/issues/issue-layouts/filters/header/edit-toggle/index.tsx
+++ b/web/components/issues/issue-layouts/filters/header/edit-toggle/index.tsx
@@ -2,20 +2,41 @@ import { ToggleSwitch } from "@plane/ui";
 import { useMobxStore } from "lib/mobx/store-provider";
 import { observer } from "mobx-react-lite";
 
-const UpdateToggle: React.FC = observer(() => {
+interface EditToggleProps {
+  value: boolean;
+  onChange: (value: boolean) => void;
+}
+
+export const ViewEditToggle: React.FC = observer(() => {
 
   const { viewIssuesFilter: {isEditing, updateEditing} } = useMobxStore();
+
+  return (
+    <EditToggle value={isEditing} onChange={updateEditing} />
+  );
+
+});
+
+export const CycleEditToggle: React.FC = observer(() => {
+
+  const { cycleIssuesFilter: {isEditing, updateEditing} } = useMobxStore();
+
+  return (
+    <EditToggle value={isEditing} onChange={updateEditing}/>
+  );
+})
+
+function EditToggle({value, onChange} : EditToggleProps) {
 
   return (
     <div className="flex items-center gap-2 border rounded p-1">
       <label className="text-sm">Edit mode:</label>
       <ToggleSwitch
         label="Edit mode"
-        value={isEditing}
-        onChange={updateEditing}
+        value={value}
+        onChange={onChange}
       />
     </div>
   );
-});
 
-export default UpdateToggle;
+}

--- a/web/components/issues/issue-layouts/roots/cycle-layout-root.tsx
+++ b/web/components/issues/issue-layouts/roots/cycle-layout-root.tsx
@@ -43,7 +43,7 @@ export const CycleLayoutRoot: React.FC = observer(() => {
         );
       }
     }
-  );
+    , {revalidateOnFocus:false});
 
   const activeLayout = issueFilters?.displayFilters?.layout;
 

--- a/web/components/issues/issue-layouts/roots/project-view-layout-root.tsx
+++ b/web/components/issues/issue-layouts/roots/project-view-layout-root.tsx
@@ -30,7 +30,7 @@ export const ProjectViewLayoutRoot: React.FC = observer(() => {
       await fetchFilters(workspaceSlug.toString(), projectId.toString(), viewId.toString());
       await fetchIssues(workspaceSlug.toString(), projectId.toString(), getIssues ? "mutation" : "init-loader");
     }
-  });
+  }, {revalidateOnFocus: false});
 
   const activeLayout = issueFilters?.displayFilters?.layout;
 

--- a/web/store/issues/project-issues/project-view/filter.store.ts
+++ b/web/store/issues/project-issues/project-view/filter.store.ts
@@ -208,8 +208,6 @@ export class ViewIssuesFilterStore extends IssueFilterBaseStore implements IView
         await this.viewService.patchView(workspaceSlug, projectId, viewId, {
           query_data: { ..._filters.filters },
         });
-      else
-        console.log("not udpated");
 
       return _filters;
     } catch (error) {


### PR DESCRIPTION
## ✨ Context

When a user applies a filter inside a cycle, that filters gets stored with the cycle. Affecting other users in the same page. Added a toggle that allows a user to turn on/off this effect, allowing users to apply filters locally without affecting other people.

Update the github button so it redirects to this repo, instead of the original one.

## 📘 Documentation

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## 🧪 Test

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [X] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

## 📸 Screenshots (optional)

https://github.com/Alternova-Inc/plane/assets/131204081/5bf059a1-bee5-49b9-b2e1-29dd167a28b6

